### PR TITLE
Add Error Handling and generalise message received

### DIFF
--- a/solace-jms-sample-app/src/main/java/demo/DemoApplication.java
+++ b/solace-jms-sample-app/src/main/java/demo/DemoApplication.java
@@ -1,20 +1,24 @@
 package demo;
 
+import java.util.Iterator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 @SpringBootApplication
 public class DemoApplication {
-
+    
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
     }
@@ -26,24 +30,39 @@ public class DemoApplication {
 
         @Autowired
         private JmsTemplate jmsTemplate;
+        
+        @Value("${solace.jms.demoQueueName}")
+        private String queueName;
 
         @Override
         public void run(String... strings) throws Exception {
             String msg = "Hello World";
             logger.info("============= Sending " + msg);
-            this.jmsTemplate.convertAndSend("testQueue", msg);
+            this.jmsTemplate.convertAndSend(queueName, msg);
         }
     }
 
     @Component
     static class MessageHandler {
-
+ 
         private static final Logger logger = LoggerFactory.getLogger(MessageHandler.class);
 
-        @JmsListener(destination = "testQueue")
-        public void processMsg(String msg) {
-            logger.info("============= Received " + msg);
+        // Retrieve the name of the queue from the application.properties file
+        @JmsListener(destination = "${solace.jms.demoQueueName}")
+        public void processMsg(Message msg) {
+        	StringBuffer msgAsStr = new StringBuffer("============= Received \nHeaders:");
+        	MessageHeaders hdrs = msg.getHeaders();
+        	msgAsStr.append("\nUUID: "+hdrs.getId());
+        	msgAsStr.append("\nTimestamp: "+hdrs.getTimestamp());
+        	Iterator<String> keyIter = hdrs.keySet().iterator();
+        	while (keyIter.hasNext()) {
+        		String key = keyIter.next();
+            	msgAsStr.append("\n"+key+": "+hdrs.get(key));        		
+        	}
+        	msgAsStr.append("\nPayload: "+msg.getPayload());
+            logger.info(msgAsStr.toString());
         }
     }
+
 
 }

--- a/solace-jms-sample-app/src/main/java/demo/DemoConfiguration.java
+++ b/solace-jms-sample-app/src/main/java/demo/DemoConfiguration.java
@@ -1,0 +1,50 @@
+package demo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+import javax.jms.ConnectionFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ErrorHandler;
+
+@EnableJms
+public class DemoConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(DemoConfiguration.class);
+
+    // In order to handle JMS errors we need to instantiate the ConnectionFactory ourselves and set the error handler
+    @Bean
+    public DefaultJmsListenerContainerFactory cFactory(ConnectionFactory connectionFactory, DemoErrorHandler errorHandler) {
+        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+        factory.setConnectionFactory(connectionFactory);
+        factory.setErrorHandler(errorHandler);
+        return factory;
+    }
+
+    @Service
+    public class DemoErrorHandler implements ErrorHandler{   
+
+        @Override
+        public void handleError(Throwable t) {
+        	ByteArrayOutputStream os = new ByteArrayOutputStream();
+        	PrintStream ps = new PrintStream(os);
+        	t.printStackTrace(ps);
+        	try {
+				String output = os.toString("UTF8");
+	            logger.error("============= Error processing message: " + t.getMessage()+"\n"+output);
+			} catch (UnsupportedEncodingException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+ 
+        }
+    }
+
+}

--- a/solace-jms-sample-app/src/main/resources/application.properties
+++ b/solace-jms-sample-app/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-solace.jms.host=192.168.0.50
+solace.jms.host=192.168.56.101
+solace.jms.demoQueueName=testQueue


### PR DESCRIPTION
Testing by sending a message using sdkperf to the Spring Boot JMS sample goes into an infinite error loop.
1.  Execution of JMS message listener failed, and no ErrorHandler has been set.
- this is resolved by adding an ErrorHandler in the DemoConfiguration class

2. By default sdkperf doesn't send a Text payload, so the following error is thrown:
```
org.springframework.jms.listener.adapter.ListenerExecutionFailedException: Listener method could not be invoked with incoming message
Endpoint handler details:
Method [public void demo.DemoApplication$MessageHandler.processMsg(java.lang.String)]
Bean [demo.DemoApplication$MessageHandler@4fcc0416]
; nested exception is org.springframework.messaging.converter.MessageConversionException: Cannot convert from [com.solacesystems.jms.message.SolMessage] to [java.lang.String] for org.springframework.jms.listener.adapter.AbstractAdaptableMessageListener$MessagingMessageConverterAdapter
```
3. Made the QueueName parameterisable to demonstrate best practice