### PR TITLE
upgrade to solace-services-info:0.4.1 + solace-spring-cloud-connector:4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Note that you'll neeed to include version 3.1.0 or later to use Spring Boot rele
 #### Using it with Gradle
 
 ```groovy
-compile("com.solace.spring.boot:solace-jms-spring-boot-starter:3.2.0")
+compile("com.solace.spring.boot:solace-jms-spring-boot-starter:3.2.1")
 ```
 
 #### Using it with Maven
@@ -68,7 +68,7 @@ compile("com.solace.spring.boot:solace-jms-spring-boot-starter:3.2.0")
 <dependency>
 	<groupId>com.solace.spring.boot</groupId>
 	<artifactId>solace-jms-spring-boot-starter</artifactId>
-	<version>3.2.0</version>
+	<version>3.2.1</version>
 </dependency>
 ```
 

--- a/solace-jms-spring-boot-autoconfigure/pom.xml
+++ b/solace-jms-spring-boot-autoconfigure/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>com.solace.cloud.core</groupId>
 			<artifactId>solace-services-info</artifactId>
-			<version>0.4.0</version>
+			<version>0.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.solacesystems</groupId>
@@ -58,7 +58,7 @@
 		<dependency>
 		  <groupId>com.solace.cloud.cloudfoundry</groupId>
 		  <artifactId>solace-spring-cloud-connector</artifactId>
-		  <version>4.1.0</version>
+		  <version>4.1.1</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.github.stefanbirkner</groupId>


### PR DESCRIPTION
Fixes transient Jackson dependency issues when Jackson 3.x is present in Maven repositories.